### PR TITLE
Update proxy url format for kubernetes v1.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ $ kubectl create clusterrolebinding open-api --clusterrole=cluster-admin --user=
 
 Login the addon's dashboard:
 - Dashboard: [https://API_SERVER:6443/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/](https://API_SERVER:6443/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/)
-- Logging: [https://API_SERVER:6443/api/v1/proxy/namespaces/kube-system/services/kibana-logging](https://API_SERVER:6443/api/v1/proxy/namespaces/kube-system/services/kibana-logging)
-- Monitor: [https://API_SERVER:6443/api/v1/proxy/namespaces/kube-system/services/monitoring-grafana](https://API_SERVER:6443/api/v1/proxy/namespaces/kube-system/services/monitoring-grafana)
+- Logging: [https://API_SERVER:6443/api/v1/namespaces/kube-system/services/kibana-logging/proxy/](https://API_SERVER:6443/api/v1/namespaces/kube-system/services/kibana-logging/proxy/)
+- Monitor: [https://API_SERVER:6443/api/v1/namespaces/kube-system/services/monitoring-grafana/proxy/](https://API_SERVER:6443/api/v1/namespaces/kube-system/services/monitoring-grafana/proxy/)
 
 As of release 1.7 Dashboard no longer has full admin privileges granted by default, so you need to create a token to access the resources:
 ```sh

--- a/roles/kubernetes/addon/templates/kube-logging/kibana.yml.j2
+++ b/roles/kubernetes/addon/templates/kube-logging/kibana.yml.j2
@@ -49,7 +49,7 @@ spec:
           - name: ELASTICSEARCH_URL
             value: http://elasticsearch-logging:9200
           - name: SERVER_BASEPATH
-            value: /api/v1/proxy/namespaces/kube-system/services/kibana-logging
+            value: /api/v1/namespaces/kube-system/services/kibana-logging/proxy/
           - name: XPACK_MONITORING_ENABLED
             value: "false"
           - name: XPACK_SECURITY_ENABLED

--- a/roles/kubernetes/addon/templates/kube-monitoring/influxdb-grafana.yml.j2
+++ b/roles/kubernetes/addon/templates/kube-monitoring/influxdb-grafana.yml.j2
@@ -96,7 +96,7 @@ spec:
             - name: GF_AUTH_ANONYMOUS_ORG_ROLE
               value: Admin
             - name: GF_SERVER_ROOT_URL
-              value: /api/v1/proxy/namespaces/kube-system/services/monitoring-grafana/
+              value: /api/v1/namespaces/kube-system/services/monitoring-grafana/proxy/
           ports:
           - name: ui
             containerPort: 3000


### PR DESCRIPTION
The proxy URL format has changed for kubernetes v1.10 ([kubernetes PR #59884](https://github.com/kubernetes/kubernetes/pull/59884/files)).