### PR TITLE
Bump version to v1.12

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -1,6 +1,6 @@
 ---
 
-kube_version: 1.11.2
+kube_version: 1.12.3
 
 # Container runtime,
 # Supported: docker, nvidia-docker, containerd.


### PR DESCRIPTION
ToDo List:
* [x] Bump default version to v1.12(e2e test completed).
* [ ] Improve role vars.
* [ ] Add CRI-O runtime.
* [ ] Rolling upgrade for an existing cluster.
