### PR TITLE
Fix docker cmd path in reset-k8s

### DIFF
--- a/roles/cluster-reset/tasks/reset-k8s.yml
+++ b/roles/cluster-reset/tasks/reset-k8s.yml
@@ -7,19 +7,19 @@
 
 - name: Stop docker containers
   when: container_runtime == 'docker' or container_runtime == 'nvidia-docker'
-  shell: "{{ bin_dir }}/docker stop $(docker ps -aq) "
+  shell: "{{ bin_dir }}/docker stop $({{ bin_dir }}/docker ps -aq) "
   ignore_errors: True
   register: stop_docker_containers
 
 - name: Clean docker containers
   when: stop_docker_containers and (container_runtime == 'docker' or container_runtime == 'nvidia-docker')
-  shell: "{{ bin_dir }}/docker rm $(docker ps -aq)"
+  shell: "{{ bin_dir }}/docker rm $({{ bin_dir }}/docker ps -aq)"
   ignore_errors: True
   register: clean_docker_containers
 
 - name: Clean docker images
   when: clean_docker_containers and (container_runtime == 'docker' or container_runtime == 'nvidia-docker')
-  shell: "{{ bin_dir }}/docker rmi $(docker images -aq)"
+  shell: "{{ bin_dir }}/docker rmi $({{ bin_dir }}/docker images -aq)"
   ignore_errors: True
   register: clean_docker_images
 


### PR DESCRIPTION
In CentOS need to use full path to using Docker.