### PR TITLE
Fix for python3 and weird is defined issue

### DIFF
--- a/roles/cluster-default/defaults/main.yml
+++ b/roles/cluster-default/defaults/main.yml
@@ -64,13 +64,13 @@ kubeproxy_ipvs_scheduler: rr
 ###############
 
 # A list of insecure registrys you might need to define
-add_registry:
+# add_registry:
 # - "gcr.io"
 
-insecure_registrys:
-# - "172.16.35.9:5000"
+# insecure_registrys:
+# - "192.168.2.9:5000"
 
-docker_opts:
+# docker_opts:
 # - "HTTP_PROXY=http://proxy.example.com:80/"
 # - "HTTPS_PROXY=https://proxy.example.com:443/"
 

--- a/roles/k8s-setup/templates/kubelet-config.yml.j2
+++ b/roles/k8s-setup/templates/kubelet-config.yml.j2
@@ -11,7 +11,7 @@ clusterDNS:
 clusterDomain: {{ cluster_domain_name }}
 {% if kubelet_feature_gates -%}
 featureGates:
-{% for k,v in kubelet_feature_gates.iteritems() %}
+{% for k,v in kubelet_feature_gates.items() %}
   {{ k }}: {{ v | lower }}
 {% endfor -%}
 {% endif -%}


### PR DESCRIPTION
I found that this will work with python 3 by updating the iteritems to items. There was a weird issue with the is defined around  the registries and docker opts yaml. If you want to leave it as defaults it would break on checking the length of a NoneType.