### PR TITLE
removing duplicate line to prevent Ansible bailing with error

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -14,5 +14,4 @@ stdout_callback = skippy
 deprecation_warnings = False
 inventory_ignore_extensions = ~, .orig, .bak, .ini, .cfg, .retry, .pyc, .pyo, .creds
 become = True
-host_key_checking = False
 callback_whitelist = profile_tasks

--- a/roles/k8s-setup/files/swapoff.service
+++ b/roles/k8s-setup/files/swapoff.service
@@ -1,0 +1,14 @@
+# /etc/systemd/system/swapoff.service
+
+[Unit]
+Description=Swapoff, kubelet requirement
+After=network.target
+Before=kubelet.service
+
+[Service]
+Type=oneshot
+ExecStart=/sbin/swapoff -a
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/k8s-setup/tasks/config-systemd.yml
+++ b/roles/k8s-setup/tasks/config-systemd.yml
@@ -19,6 +19,21 @@
 - name: Disable vm swappiness
   shell: "swapoff -a && sysctl -w vm.swappiness=0"
 
+- name: copy new SystemD file for swapoff.service
+  copy:
+    src: swapoff.service
+    dest: /etc/systemd/system/swapoff.service
+    owner: root
+    group: root
+    mode: 0644
+
+- name: install and enbale SystemD swapoff.service
+  systemd:
+    name: swapoff
+    daemon_reload: yes
+    enabled: yes
+    state: started
+    
 - name: Enable and restart kubelet engine
   systemd:
     name: kubelet

--- a/roles/k8s-setup/tasks/config-systemd.yml
+++ b/roles/k8s-setup/tasks/config-systemd.yml
@@ -33,7 +33,7 @@
     daemon_reload: yes
     enabled: yes
     state: started
-    
+
 - name: Enable and restart kubelet engine
   systemd:
     name: kubelet


### PR DESCRIPTION
The option in ansible.cfg 'host_key_checking = False" is in there two times. This caused Ansible to bail with error:

```==> k8s-n2: Running provisioner: cluster (ansible)...
Vagrant gathered an unknown Ansible version:


and falls back on the compatibility mode '1.8'.

Alternatively, the compatibility mode can be specified in your Vagrantfile:
https://www.vagrantup.com/docs/provisioning/ansible_common.html#compatibility_mode

    k8s-n2: Running ansible-playbook...
Error reading config file (/home/willert/git/kube-ansible/ansible.cfg): While reading from '<string>' [line 17]: option 'host_key_checking' in section 'defaults' already exists
Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again.
```
