### PR TITLE
ELK update to 7.4.0

### DIFF
--- a/roles/k8s-addon/templates/logging/elasticsearch/elasticsearch-sts.yml.j2
+++ b/roles/k8s-addon/templates/logging/elasticsearch/elasticsearch-sts.yml.j2
@@ -32,7 +32,7 @@ spec:
           privileged: true
       containers:
       - name: elasticsearch-logging
-        image: gcr.io/fluentd-elasticsearch/elasticsearch:v6.6.1
+        image: docker.elastic.co/elasticsearch/elasticsearch:7.4.0
         resources:
           limits:
             cpu: 1000m
@@ -49,6 +49,16 @@ spec:
         - name: elasticsearch-logging
           mountPath: /data
         env:
+        - name: cluster.name
+          value: elasticsearch-logging
+        - name: node.name
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: discovery.zen.ping.unicast.hosts
+          value: "elasticsearch-discovery.kube-system.svc.cluster.local"
+        - name: cluster.initial_master_nodes
+          value: "elasticsearch-logging-0,elasticsearch-logging-1"
         - name: "NAMESPACE"
           valueFrom:
             fieldRef:

--- a/roles/k8s-addon/templates/logging/elasticsearch/elasticsearch-svc.yml.j2
+++ b/roles/k8s-addon/templates/logging/elasticsearch/elasticsearch-svc.yml.j2
@@ -13,3 +13,25 @@ spec:
     targetPort: db
   selector:
     k8s-app: elasticsearch-logging
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: kube-system
+  name: elasticsearch-discovery
+  labels:
+    service: elasticsearch
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+  - port: 9200
+    name: db
+    targetPort: db
+  - port: 9300
+    name: transport
+    targetPort: transport
+  selector:
+    k8s-app: elasticsearch-logging

--- a/roles/k8s-addon/templates/logging/kibana/kibana-dp.yml.j2
+++ b/roles/k8s-addon/templates/logging/kibana/kibana-dp.yml.j2
@@ -20,14 +20,14 @@ spec:
     spec:
       containers:
       - name: kibana-logging
-        image: docker.elastic.co/kibana/kibana-oss:6.6.1
+        image: docker.elastic.co/kibana/kibana:7.4.0
         resources:
           limits:
             cpu: 1000m
           requests:
             cpu: 100m
         env:
-          - name: ELASTICSEARCH_URL
+          - name: ELASTICSEARCH_HOSTS
             value: http://elasticsearch-logging:9200
           - name: SERVER_BASEPATH
             value: /api/v1/namespaces/kube-system/services/kibana-logging/proxy


### PR DESCRIPTION
Hello,
updated deployment to use the latest ELK stack.

Included changes:
 * updated version to 7.4.0;
 * usage of official docker images from docker.elastic.co;
 * introduced new headless service for elastic pods discovery;