### PR TITLE
Allow customizing kubelet resolvConf setting

### DIFF
--- a/roles/k8s-setup/defaults/main.yml
+++ b/roles/k8s-setup/defaults/main.yml
@@ -23,6 +23,7 @@ kubelet_bind_healthz_address: 127.0.0.1
 kubelet_bind_port: 10250
 kubelet_bind_read_port: 10255
 kubelet_bind_healthz_port: 10248
+kubelet_resolv_conf: /etc/resolv.conf
 
 # keepalived variables
 keepalived_unicast_peers: "{% for host in groups['masters'] %}{% if vip_interface != '' %}'{{ hostvars[host]['ansible_' + vip_interface].ipv4.address }}'{% else %}'{{ hostvars[host].ansible_default_ipv4.address }}'{% endif %}{% if not loop.last %},{% endif %}{% endfor %}"

--- a/roles/k8s-setup/templates/kubelet-config.yml.j2
+++ b/roles/k8s-setup/templates/kubelet-config.yml.j2
@@ -67,7 +67,7 @@ oomScoreAdj: -999
 podPidsLimit: -1
 registryBurst: 10
 registryPullQPS: 5
-resolvConf: /etc/resolv.conf
+resolvConf: {{ kubelet_resolv_conf }}
 rotateCertificates: true
 runtimeRequestTimeout: 2m0s
 serializeImagePulls: true


### PR DESCRIPTION
Introduce the `kubelet_resolv_conf` variable. This allows to customize
which `resolv.conf` file is being used by kubelet when creating a new
pod.

This is especially useful on nodes running `systemd-resolved`, like
Ubuntu Bionic, where `/run/systemd/resolve/resolv.conf` may be used
instead of `/etc/resolv.conf` in order to avoid a DNS resolution loop
as described there: https://coredns.io/plugins/loop/